### PR TITLE
Add restore bar mode

### DIFF
--- a/src/focus.rs
+++ b/src/focus.rs
@@ -179,6 +179,8 @@ impl Focus {
         let swaync = SwayNCInterface::new().await?;
         let mut sway = SwayIpcInterface::new().await?;
 
+        let bar_mode = sway.get_bar_mode().await?;
+
         // Set the tools to the desired state
         swaync.enable_dnd().await?;
         if !self.config.keep_status_bar {
@@ -233,7 +235,7 @@ impl Focus {
         swaync.disable_dnd().await?;
 
         if !self.config.keep_status_bar {
-            sway.set_bar_mode_dock().await?;
+            sway.restore_bar_mode(bar_mode).await?;
         }
 
         let mut hints = HashMap::new();

--- a/src/sway_ipc_interface.rs
+++ b/src/sway_ipc_interface.rs
@@ -1,4 +1,4 @@
-// src/ipc.rs
+use log::debug;
 use swayipc_async::Connection;
 
 pub struct SwayIpcInterface {
@@ -22,5 +22,40 @@ impl SwayIpcInterface {
 
     pub async fn set_bar_mode_dock(&mut self) -> Result<(), swayipc_async::Error> {
         self.run_command("bar mode dock").await
+    }
+
+    pub async fn set_bar_mode_hide(&mut self) -> Result<(), swayipc_async::Error> {
+        self.run_command("bar mode hide").await
+    }
+
+    pub async fn get_bar_mode(&mut self) -> Result<swayipc_async::BarMode, swayipc_async::Error> {
+        let ids = self.connection.get_bar_ids().await?;
+        if let Some(first_id) = ids.first() {
+            let bar_config = self.connection.get_bar_config(first_id.to_string()).await?;
+            Ok(bar_config.mode)
+        } else {
+            Ok(swayipc_async::BarMode::Dock)
+        }
+    }
+
+    pub async fn restore_bar_mode(
+        &mut self,
+        bar_mode: swayipc_async::BarMode,
+    ) -> Result<(), swayipc_async::Error> {
+        // Do not restore if the mode has change since the timer was started
+        // swayipc_async::BarMode does not implement PartialEq
+        if format!("{:?}", self.get_bar_mode().await?)
+            != format!("{:?}", swayipc_async::BarMode::Invisible)
+        {
+            debug!("Bar mode not 'Invisible' anymore, has changed externally. Not restoring.");
+            return Ok(());
+        }
+        debug!("Restoring bar mode to {:?}", bar_mode);
+        match bar_mode {
+            swayipc_async::BarMode::Dock => self.set_bar_mode_dock().await,
+            swayipc_async::BarMode::Invisible => self.set_bar_mode_invisible().await,
+            swayipc_async::BarMode::Hide => self.set_bar_mode_hide().await,
+            _ => Ok(()),
+        }
     }
 }


### PR DESCRIPTION
Restore the mode of the bar to the value it has been when focus mode was started.
Add call to get the bar mode.
Add function to restore mode. It will only restore to the previous mode if no change in the mode was detected. Assuming the user change the mode while the focus timer was running, don't change it to something else.