### PR TITLE
Handle set of bars

### DIFF
--- a/src/focus.rs
+++ b/src/focus.rs
@@ -184,7 +184,7 @@ impl Focus {
         // Set the tools to the desired state
         swaync.enable_dnd().await?;
         if !self.config.keep_status_bar {
-            sway.set_bar_mode_invisible().await?;
+            sway.set_bars_invisible().await?;
         }
 
         // Set the Ctrl+C handler


### PR DESCRIPTION
Save the bar mode for each bar and restore them individually. Combine bar mode change into one function.
Provide only one public interface to change mode to 'invisible' for all bars.