### PR TITLE
docs: add cargo install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Clone the repository and build the project:
 $ git clone https://github.com/towoe/focus-time.git
 $ cd focus-time
 $ cargo build --release
+$ cargo install --path .
 ```
+
+The binary will be installed to `~/.cargo/bin/`. Make sure this directory is in
+your `PATH` environment variable.
 
 ## Usage
 


### PR DESCRIPTION
Add instructions for installing the binary using cargo install command and note about adding ~/.cargo/bin to PATH environment variable.