### PR TITLE
feat: add client commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,28 @@ keep-status-bar = false
 print-time = false
 ```
 
-## Client access
+## Controlling a running instance
 
-When the application is running, it can be accessed via D-Bus, to retrieve the
-remaining time and to stop it.
+When the application is running, you can control it using subcommands. This is
+achieved by communicating with the running instance over its D-Bus interface.
 
-For example, `busctl` can be used to print the remaining time:
+- `focus-time status`: Show the remaining time and pause state.
+- `focus-time toggle-pause`: Toggle the pause state of the timer.
+- `focus-time stop`: Stop the timer.
 
+Example:
 ```sh
-$ busctl --user call org.towoe.FocusTime /org/towoe/FocusTime \
-  org.towoe.FocusTime GetRemainingTime
-```
+$ focus-time status
+14:32
 
-```sh
-$ busctl --user call org.towoe.FocusTime /org/towoe/FocusTime \
-  org.towoe.FocusTime TogglePause
-```
+$ focus-time toggle-pause
+Focus timer toggled pause.
 
+$ focus-time status
+14:32 (paused)
+
+$ focus-time stop
+Focus timer stopped.
 ## Integration
 
 To integrate Focus Time with Sway, you can bind keys to start a 25-minute focus
@@ -83,6 +88,5 @@ session and stop the timer using the following configuration.
 ```ini
 # Focus time
 bindsym $mod+o exec focus-time 25m
-bindsym $mod+Shift+o exec busctl --user call org.towoe.FocusTime \
-/org/towoe/FocusTime org.towoe.FocusTime StopTimer
+bindsym $mod+Shift+o exec focus-time stop
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 /// Command line interface for the wait command
 #[derive(Parser)]
@@ -7,6 +7,9 @@ use clap::Parser;
     about = "Create distraction free environment for a limited time."
 )]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
     /// Duration to wait (e.g. "5s", "2m", "1h")
     pub duration: Option<String>,
 
@@ -29,4 +32,14 @@ pub struct Cli {
     /// Log level (e.g. "trace", "debug", "info", "warn", "error")
     #[arg(short, long, default_value = "error")]
     pub log_level: String,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Stop the timer
+    Stop,
+    /// Pause/Resume the timer
+    TogglePause,
+    /// Get the status of the timer
+    Status,
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,44 @@
+use crate::cli::Commands;
+use anyhow::Result;
+use zbus::Connection;
+
+use zbus::proxy;
+
+#[proxy(
+    interface = "org.towoe.FocusTime",
+    default_service = "org.towoe.FocusTime",
+    default_path = "/org/towoe/FocusTime"
+)]
+pub trait FocusTimer {
+    fn get_remaining_time(&self) -> zbus::Result<String>;
+    fn get_paused(&self) -> zbus::Result<bool>;
+    fn stop_timer(&self) -> zbus::Result<()>;
+    fn toggle_pause(&self) -> zbus::Result<()>;
+}
+
+pub async fn handle_command(command: Commands) -> Result<()> {
+    let connection = Connection::session().await?;
+    let proxy = FocusTimerProxy::new(&connection).await?;
+
+    match command {
+        Commands::Stop => {
+            proxy.stop_timer().await?;
+            println!("Focus timer stopped.");
+        }
+        Commands::TogglePause => {
+            proxy.toggle_pause().await?;
+            println!("Focus timer toggled pause.");
+        }
+        Commands::Status => {
+            let time = proxy.get_remaining_time().await?;
+            let paused = proxy.get_paused().await?;
+            if paused {
+                println!("{time} (paused)");
+            } else {
+                println!("{time}");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod client;
 mod config;
 mod focus;
 mod focus_interface;
@@ -46,8 +47,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log the start of the focus timer
     info!("Starting focus timer");
 
-    // Start the focus timer with the parsed arguments
-    focus::new(args)?.run().await?;
+    // Handle subcommands or start the focus timer
+    if let Some(command) = args.command {
+        client::handle_command(command).await?;
+    } else {
+        focus::new(args)?.run().await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Add status, stop, and toggle-pause subcommands that communicate with the running focus timer via D-Bus.